### PR TITLE
[DSNP 1.2.0] Breaking change: Require published field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changes
 - Types are now exported out of `/types` instead of `/factories`
 - Update dependencies
+- Activity Content Note now requires published field per DSNP 1.2.0
 
 ## [1.0.1] - 2022-04-28
 ### Changes

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -20,16 +20,19 @@ import type {
  * createNote() provides a simple factory for generating an ActivityContentNote
  * object.
  * @param content - The text content to include in the note
+ * @param published - the Date that the note was claimed to be published
  * @param options - Overrides default fields for the ActivityContentNote
  * @returns An ActivityContentNote object
  */
 export const createNote = (
   content: string,
+  published: Date,
   options?: Partial<ActivityContentNote>
 ): ActivityContentNote => ({
   "@context": "https://www.w3.org/ns/activitystreams",
   type: "Note",
   mediaType: "text/plain",
+  published: published.toISOString(),
   content,
   ...options,
 });

--- a/src/test/factories.test.ts
+++ b/src/test/factories.test.ts
@@ -17,13 +17,17 @@ import {
 describe("activityPub", () => {
   describe("createNote", () => {
     it("returns an ActivityContentNote with the given parameters", () => {
-      const activityContentNote = createNote("Hello World!");
+      const activityContentNote = createNote(
+        "Hello World!",
+        new Date("2020-01-01T17:30:00.000Z")
+      );
 
       expect(activityContentNote).toMatchObject({
         "@context": "https://www.w3.org/ns/activitystreams",
         type: "Note",
         content: "Hello World!",
         mediaType: "text/plain",
+        published: "2020-01-01T17:30:00.000Z",
       });
     });
   });

--- a/src/test/validation.test.ts
+++ b/src/test/validation.test.ts
@@ -80,14 +80,25 @@ describe("activity content validations", () => {
         type: "Note",
         content: "Hello world!",
         mediaType: "text/plain",
+        published: "2000-01-01T00:00:00.000+00:00",
       };
       expect(isActivityContentNoteType(validNote)).toEqual(true);
     });
-    it("returns false for an invalid Note", () => {
+    it("returns false for an invalid Note: mediaType", () => {
       const invalidNote = {
         "@context": "https://www.w3.org/ns/activitystreams",
         type: "Note",
         content: "I am invalid because I am missing a mediaType",
+        published: "2000-01-01T00:00:00.000+00:00",
+      };
+      expect(isActivityContentNoteType(invalidNote)).toEqual(false);
+    });
+    it("returns false for an invalid Note: published", () => {
+      const invalidNote = {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        type: "Note",
+        mediaType: "text/plain",
+        content: "I am invalid because I am missing a published",
       };
       expect(isActivityContentNoteType(invalidNote)).toEqual(false);
     });
@@ -595,18 +606,21 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Hello world!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
         },
         "with no attachments and no content": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
           content: "",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
         },
         "with a hashtag": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
           content: "Hello world!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           tag: [{ name: "happiness" }, { name: "feels" }, { name: "kawaii" }],
         },
         "with a mention": {
@@ -614,6 +628,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Hello world!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           tag: [
             { type: "Mention", id: "dsnp://1001", name: "Spoopy" },
             { type: "Mention", id: "dsnp://1002", name: "Snoopy" },
@@ -624,6 +639,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Feel like I've heard this before!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Audio",
@@ -649,6 +665,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Interesting guy!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Image",
@@ -674,6 +691,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "What an adventure!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Video",
@@ -700,6 +718,7 @@ describe("activity content validations", () => {
             type: "Note",
             content: "What an adventure!",
             mediaType: "text/plain",
+            published: "2000-01-01T00:00:00.000+00:00",
             attachment: [
               {
                 type: "Video",
@@ -737,6 +756,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Interesting project!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Link",
@@ -749,6 +769,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Hello world!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           location: {
             type: "Place",
             name: "Topkapi Palace, Istanbul, Turkey",
@@ -999,12 +1020,14 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Hello world!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
         },
         "a note with an audio attachment": {
           "@context": "https://www.w3.org/ns/activitystreams",
           type: "Note",
           content: "Feel like I've heard this before!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Audio",
@@ -1030,6 +1053,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Interesting guy!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Image",
@@ -1055,6 +1079,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "What an adventure!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Video",
@@ -1080,6 +1105,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Interesting project!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Link",
@@ -1092,6 +1118,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Interesting project!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           attachment: [
             {
               type: "Link",
@@ -1112,6 +1139,7 @@ describe("activity content validations", () => {
           type: "Note",
           content: "Interesting project!",
           mediaType: "text/plain",
+          published: "2000-01-01T00:00:00.000+00:00",
           location: { type: "Place", name: "Valjevo, Serbia" },
         },
       };
@@ -1154,6 +1182,7 @@ describe("activity content validations", () => {
             type: "Note",
             content: "Interesting project!",
             mediaType: "text/plain",
+            published: "2000-01-01T00:00:00.000+00:00",
           },
         },
         {
@@ -1164,6 +1193,17 @@ describe("activity content validations", () => {
               type: "bad",
               name: "This is fine",
             },
+            "@context": "https://www.w3.org/ns/activitystreams",
+            type: "Note",
+            content: "Interesting project!",
+            mediaType: "text/plain",
+            published: "2000-01-01T00:00:00.000+00:00",
+          },
+        },
+        {
+          name: "with a note object that is not a valid published",
+          expErr: "ActivityContentNote published is not a string",
+          note: {
             "@context": "https://www.w3.org/ns/activitystreams",
             type: "Note",
             content: "Interesting project!",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface ActivityContentNote extends ActivityContentBase {
   mediaType: "text/plain";
   content: string;
   attachment?: Array<ActivityContentAttachment>;
+  published: string;
 }
 
 /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -495,6 +495,7 @@ export const requireIsActivityContentNoteType = (
     );
   if (obj["attachment"])
     requireToArray(obj["attachment"], "ActivityContentNote attachment");
+  requireToString(obj["published"], "ActivityContentNote published");
   return true;
 };
 


### PR DESCRIPTION
Problem
=======
DSNP 1.2.0 Requires the Published Field on Activity Content Note

Part of: #19 

Solution
========
Required the field and updated the needed tests

Double Checks:
---------------
- [x] Did you update the changelog?
- [x] Any new modules need to be exported?
- [x] Are new methods in the right module?
- [x] Do you have good documentation on exported methods?

Change summary:
---------------
* Required published

Steps to Verify:
----------------
1. Validate or create an Activity Content Note without published and get an error